### PR TITLE
Fix conflict between icons

### DIFF
--- a/foundation_icons_accessibility/demo.html
+++ b/foundation_icons_accessibility/demo.html
@@ -82,29 +82,28 @@
     <div class="row">
 
       <ul class="four columns">
-        <li><i class="foundicon-wheelchair"></i></li>
-        <li><i class="foundicon-speaker"></i></li>
-        <li><i class="foundicon-fontsize"></i></li>
-        <li><i class="foundicon-eject"></i></li>
-        <li><i class="foundicon-view-mode"></i></li>
-        <li><i class="foundicon-eyeball"></i></li>
-
-        <li><i class="foundicon-asl"></i></li>
-        <li><i class="foundicon-person"></i></li>
-        <li><i class="foundicon-question"></i></li>
+        <li><i class="accessibility foundicon-wheelchair"></i></li>
+        <li><i class="accessibility foundicon-speaker"></i></li>
+        <li><i class="accessibility foundicon-fontsize"></i></li>
+        <li><i class="accessibility foundicon-eject"></i></li>
+        <li><i class="accessibility foundicon-view-mode"></i></li>
+        <li><i class="accessibility foundicon-eyeball"></i></li>
+        <li><i class="accessibility foundicon-asl"></i></li>
+        <li><i class="accessibility foundicon-person"></i></li>
+        <li><i class="accessibility foundicon-question"></i></li>
         
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-adult"></i></li>
-        <li><i class="foundicon-child"></i></li>
-        <li><i class="foundicon-glasses"></i></li>
-        <li><i class="foundicon-cc"></i></li>
-        <li><i class="foundicon-blind"></i></li>
-        <li><i class="foundicon-braille"></i></li>
-        <li><i class="foundicon-iphone-home"></i></li>
-        <li><i class="foundicon-w3c"></i></li>
-        <li><i class="foundicon-css"></i></li>
+        <li><i class="accessibility foundicon-adult"></i></li>
+        <li><i class="accessibility foundicon-child"></i></li>
+        <li><i class="accessibility foundicon-glasses"></i></li>
+        <li><i class="accessibility foundicon-cc"></i></li>
+        <li><i class="accessibility foundicon-blind"></i></li>
+        <li><i class="accessibility foundicon-braille"></i></li>
+        <li><i class="accessibility foundicon-iphone-home"></i></li>
+        <li><i class="accessibility foundicon-w3c"></i></li>
+        <li><i class="accessibility foundicon-css"></i></li>
 
         
         
@@ -112,14 +111,14 @@
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-key"></i></li>
-        <li><i class="foundicon-hearing-impaired"></i></li>
-        <li><i class="foundicon-male"></i></li>
-        <li><i class="foundicon-female"></i></li>
-        <li><i class="foundicon-network"></i></li>
-        <li><i class="foundicon-guidedog"></i></li>
-        <li><i class="foundicon-universal-access"></i></li>
-        <li><i class="foundicon-elevator"></i></li>
+        <li><i class="accessibility foundicon-key"></i></li>
+        <li><i class="accessibility foundicon-hearing-impaired"></i></li>
+        <li><i class="accessibility foundicon-male"></i></li>
+        <li><i class="accessibility foundicon-female"></i></li>
+        <li><i class="accessibility foundicon-network"></i></li>
+        <li><i class="accessibility foundicon-guidedog"></i></li>
+        <li><i class="accessibility foundicon-universal-access"></i></li>
+        <li><i class="accessibility foundicon-elevator"></i></li>
       </ul>
 
     </div>

--- a/foundation_icons_accessibility/sass/accessibility_foundicons.scss
+++ b/foundation_icons_accessibility/sass/accessibility_foundicons.scss
@@ -14,7 +14,7 @@
   background-position: 0 0;
   background-repeat: repeat;
 }
-[class*="#{$classPrefix}"]:before {
+[class*="accessibility #{$classPrefix}"]:before {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_accessibility/sass/accessibility_foundicons_ie7.scss
+++ b/foundation_icons_accessibility/sass/accessibility_foundicons_ie7.scss
@@ -1,7 +1,7 @@
 @import "settings";
 
 /* general icons for IE7 */
-[class*="#{$classPrefix}"] {
+[class*="accessibility #{$classPrefix}"] {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_accessibility/stylesheets/accessibility_foundicons.css
+++ b/foundation_icons_accessibility/stylesheets/accessibility_foundicons.css
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="accessibility foundicon-"]:before {
   font-family: "AccessibilityFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_accessibility/stylesheets/accessibility_foundicons_ie7.css
+++ b/foundation_icons_accessibility/stylesheets/accessibility_foundicons_ie7.css
@@ -1,5 +1,5 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="accessibility foundicon-"] {
   font-family: "AccessibilityFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general/demo.html
+++ b/foundation_icons_general/demo.html
@@ -111,65 +111,65 @@
 
       <ul class="three columns">
         <li><i class="button foundicon-settings"></i></li>
-        <li><i class="foundicon-heart"></i></li>
-        <li><i class="foundicon-star"></i></li>
-        <li><i class="foundicon-plus"></i></li>
-        <li><i class="foundicon-minus"></i></li>
-        <li class="last-in-row"><i class="foundicon-checkmark"></i></li>
+        <li><i class="general foundicon-heart"></i></li>
+        <li><i class="general foundicon-star"></i></li>
+        <li><i class="general foundicon-plus"></i></li>
+        <li><i class="general foundicon-minus"></i></li>
+        <li class="last-in-row"><i class="general foundicon-checkmark"></i></li>
 
-        <li><i class="foundicon-remove"></i></li>
-        <li><i class="foundicon-mail"></i></li>
-        <li><i class="foundicon-calendar"></i></li>
-        <li><i class="foundicon-page"></i></li>
-        <li><i class="foundicon-tools"></i></li>
-        <li class="last-in-row"><i class="foundicon-globe"></i></li>
+        <li><i class="general foundicon-remove"></i></li>
+        <li><i class="general foundicon-mail"></i></li>
+        <li><i class="general foundicon-calendar"></i></li>
+        <li><i class="general foundicon-page"></i></li>
+        <li><i class="general foundicon-tools"></i></li>
+        <li class="last-in-row"><i class="general foundicon-globe"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-home"></i></li>
-        <li><i class="foundicon-quote"></i></li>
-        <li><i class="foundicon-people"></i></li>
-        <li><i class="foundicon-monitor"></i></li>
-        <li><i class="foundicon-laptop"></i></li>
-        <li class="last-in-row"><i class="foundicon-phone"></i></li>
+        <li><i class="general foundicon-home"></i></li>
+        <li><i class="general foundicon-quote"></i></li>
+        <li><i class="general foundicon-people"></i></li>
+        <li><i class="general foundicon-monitor"></i></li>
+        <li><i class="general foundicon-laptop"></i></li>
+        <li class="last-in-row"><i class="general foundicon-phone"></i></li>
 
-        <li><i class="foundicon-cloud"></i></li>
-        <li><i class="foundicon-error"></i></li>
-        <li><i class="foundicon-right-arrow"></i></li>
-        <li><i class="foundicon-left-arrow"></i></li>
-        <li><i class="foundicon-up-arrow"></i></li>
-        <li class="last-in-row"><i class="foundicon-down-arrow"></i></li>
+        <li><i class="general foundicon-cloud"></i></li>
+        <li><i class="general foundicon-error"></i></li>
+        <li><i class="general foundicon-right-arrow"></i></li>
+        <li><i class="general foundicon-left-arrow"></i></li>
+        <li><i class="general foundicon-up-arrow"></i></li>
+        <li class="last-in-row"><i class="general foundicon-down-arrow"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-trash"></i></li>
-        <li><i class="foundicon-add-doc"></i></li>
-        <li><i class="foundicon-edit"></i></li>
-        <li><i class="foundicon-lock"></i></li>
-        <li><i class="foundicon-unlock"></i></li>
-        <li class="last-in-row"><i class="foundicon-refresh"></i></li>
+        <li><i class="general foundicon-trash"></i></li>
+        <li><i class="general foundicon-add-doc"></i></li>
+        <li><i class="general foundicon-edit"></i></li>
+        <li><i class="general foundicon-lock"></i></li>
+        <li><i class="general foundicon-unlock"></i></li>
+        <li class="last-in-row"><i class="general foundicon-refresh"></i></li>
 
-        <li><i class="foundicon-paper-clip"></i></li>
-        <li><i class="foundicon-video"></i></li>
-        <li><i class="foundicon-photo"></i></li>
-        <li><i class="foundicon-graph"></i></li>
-        <li><i class="foundicon-idea"></i></li>
-        <li class="last-in-row"><i class="foundicon-mic"></i></li>
+        <li><i class="general foundicon-paper-clip"></i></li>
+        <li><i class="general foundicon-video"></i></li>
+        <li><i class="general foundicon-photo"></i></li>
+        <li><i class="general foundicon-graph"></i></li>
+        <li><i class="general foundicon-idea"></i></li>
+        <li class="last-in-row"><i class="general foundicon-mic"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-cart"></i></li>
-        <li><i class="foundicon-address-book"></i></li>
-        <li><i class="foundicon-compass"></i></li>
-        <li><i class="foundicon-flag"></i></li>
-        <li><i class="foundicon-location"></i></li>
-        <li class="last-in-row"><i class="foundicon-clock"></i></li>
+        <li><i class="general foundicon-cart"></i></li>
+        <li><i class="general foundicon-address-book"></i></li>
+        <li><i class="general foundicon-compass"></i></li>
+        <li><i class="general foundicon-flag"></i></li>
+        <li><i class="general foundicon-location"></i></li>
+        <li class="last-in-row"><i class="general foundicon-clock"></i></li>
 
-        <li><i class="foundicon-folder"></i></li>
-        <li><i class="foundicon-inbox"></i></li>
-        <li><i class="foundicon-website"></i></li>
-        <li><i class="foundicon-smiley"></i></li>
-        <li><i class="foundicon-search"></i></li>
+        <li><i class="general foundicon-folder"></i></li>
+        <li><i class="general foundicon-inbox"></i></li>
+        <li><i class="general foundicon-website"></i></li>
+        <li><i class="general foundicon-smiley"></i></li>
+        <li><i class="general foundicon-search"></i></li>
       </ul>
 
     </div>

--- a/foundation_icons_general/sass/general_foundicons.scss
+++ b/foundation_icons_general/sass/general_foundicons.scss
@@ -14,7 +14,7 @@
   background-position: 0 0;
   background-repeat: repeat;
 }
-[class*="#{$classPrefix}"]:before {
+[class*="general #{$classPrefix}"]:before {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general/sass/general_foundicons_ie7.scss
+++ b/foundation_icons_general/sass/general_foundicons_ie7.scss
@@ -1,7 +1,7 @@
 @import "settings";
 
 /* general icons for IE7 */
-[class*="#{$classPrefix}"] {
+[class*="general #{$classPrefix}"] {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general/stylesheets/general_foundicons.css
+++ b/foundation_icons_general/stylesheets/general_foundicons.css
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="general foundicon-"]:before {
   font-family: "GeneralFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general/stylesheets/general_foundicons_ie7.css
+++ b/foundation_icons_general/stylesheets/general_foundicons_ie7.css
@@ -1,5 +1,5 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="general foundicon-"] {
   font-family: "GeneralFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general_enclosed/demo.html
+++ b/foundation_icons_general_enclosed/demo.html
@@ -112,65 +112,65 @@
 
       <ul class="three columns">
         <li><i class="button foundicon-settings"></i></li>
-        <li><i class="foundicon-heart"></i></li>
-        <li><i class="foundicon-star"></i></li>
-        <li><i class="foundicon-plus"></i></li>
-        <li><i class="foundicon-minus"></i></li>
-        <li class="last-in-row"><i class="foundicon-checkmark"></i></li>
+        <li><i class="general-enclosed foundicon-heart"></i></li>
+        <li><i class="general-enclosed foundicon-star"></i></li>
+        <li><i class="general-enclosed foundicon-plus"></i></li>
+        <li><i class="general-enclosed foundicon-minus"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-checkmark"></i></li>
 
-        <li><i class="foundicon-remove"></i></li>
-        <li><i class="foundicon-mail"></i></li>
-        <li><i class="foundicon-calendar"></i></li>
-        <li><i class="foundicon-page"></i></li>
-        <li><i class="foundicon-tools"></i></li>
-        <li class="last-in-row"><i class="foundicon-globe"></i></li>
+        <li><i class="general-enclosed foundicon-remove"></i></li>
+        <li><i class="general-enclosed foundicon-mail"></i></li>
+        <li><i class="general-enclosed foundicon-calendar"></i></li>
+        <li><i class="general-enclosed foundicon-page"></i></li>
+        <li><i class="general-enclosed foundicon-tools"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-globe"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-home"></i></li>
-        <li><i class="foundicon-quote"></i></li>
-        <li><i class="foundicon-people"></i></li>
-        <li><i class="foundicon-monitor"></i></li>
-        <li><i class="foundicon-laptop"></i></li>
-        <li class="last-in-row"><i class="foundicon-phone"></i></li>
+        <li><i class="general-enclosed foundicon-home"></i></li>
+        <li><i class="general-enclosed foundicon-quote"></i></li>
+        <li><i class="general-enclosed foundicon-people"></i></li>
+        <li><i class="general-enclosed foundicon-monitor"></i></li>
+        <li><i class="general-enclosed foundicon-laptop"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-phone"></i></li>
 
-        <li><i class="foundicon-cloud"></i></li>
-        <li><i class="foundicon-error"></i></li>
-        <li><i class="foundicon-right-arrow"></i></li>
-        <li><i class="foundicon-left-arrow"></i></li>
-        <li><i class="foundicon-up-arrow"></i></li>
-        <li class="last-in-row"><i class="foundicon-down-arrow"></i></li>
+        <li><i class="general-enclosed foundicon-cloud"></i></li>
+        <li><i class="general-enclosed foundicon-error"></i></li>
+        <li><i class="general-enclosed foundicon-right-arrow"></i></li>
+        <li><i class="general-enclosed foundicon-left-arrow"></i></li>
+        <li><i class="general-enclosed foundicon-up-arrow"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-down-arrow"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-trash"></i></li>
-        <li><i class="foundicon-add-doc"></i></li>
-        <li><i class="foundicon-edit"></i></li>
-        <li><i class="foundicon-lock"></i></li>
-        <li><i class="foundicon-unlock"></i></li>
-        <li class="last-in-row"><i class="foundicon-refresh"></i></li>
+        <li><i class="general-enclosed foundicon-trash"></i></li>
+        <li><i class="general-enclosed foundicon-add-doc"></i></li>
+        <li><i class="general-enclosed foundicon-edit"></i></li>
+        <li><i class="general-enclosed foundicon-lock"></i></li>
+        <li><i class="general-enclosed foundicon-unlock"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-refresh"></i></li>
 
-        <li><i class="foundicon-paper-clip"></i></li>
-        <li><i class="foundicon-video"></i></li>
-        <li><i class="foundicon-photo"></i></li>
-        <li><i class="foundicon-graph"></i></li>
-        <li><i class="foundicon-idea"></i></li>
-        <li class="last-in-row"><i class="foundicon-mic"></i></li>
+        <li><i class="general-enclosed foundicon-paper-clip"></i></li>
+        <li><i class="general-enclosed foundicon-video"></i></li>
+        <li><i class="general-enclosed foundicon-photo"></i></li>
+        <li><i class="general-enclosed foundicon-graph"></i></li>
+        <li><i class="general-enclosed foundicon-idea"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-mic"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-cart"></i></li>
-        <li><i class="foundicon-address-book"></i></li>
-        <li><i class="foundicon-compass"></i></li>
-        <li><i class="foundicon-flag"></i></li>
-        <li><i class="foundicon-location"></i></li>
-        <li class="last-in-row"><i class="foundicon-clock"></i></li>
+        <li><i class="general-enclosed foundicon-cart"></i></li>
+        <li><i class="general-enclosed foundicon-address-book"></i></li>
+        <li><i class="general-enclosed foundicon-compass"></i></li>
+        <li><i class="general-enclosed foundicon-flag"></i></li>
+        <li><i class="general-enclosed foundicon-location"></i></li>
+        <li class="last-in-row"><i class="general-enclosed foundicon-clock"></i></li>
 
-        <li><i class="foundicon-folder"></i></li>
-        <li><i class="foundicon-inbox"></i></li>
-        <li><i class="foundicon-website"></i></li>
-        <li><i class="foundicon-smiley"></i></li>
-        <li><i class="foundicon-search"></i></li>
+        <li><i class="general-enclosed foundicon-folder"></i></li>
+        <li><i class="general-enclosed foundicon-inbox"></i></li>
+        <li><i class="general-enclosed foundicon-website"></i></li>
+        <li><i class="general-enclosed foundicon-smiley"></i></li>
+        <li><i class="general-enclosed foundicon-search"></i></li>
       </ul>
 
     </div>

--- a/foundation_icons_general_enclosed/sass/general_enclosed_foundicons.scss
+++ b/foundation_icons_general_enclosed/sass/general_enclosed_foundicons.scss
@@ -14,7 +14,7 @@
   background-position: 0 0;
   background-repeat: repeat;
 }
-[class*="#{$classPrefix}"]:before {
+[class*="general-enclosed #{$classPrefix}"]:before {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general_enclosed/sass/general_enclosed_foundicons_ie7.scss
+++ b/foundation_icons_general_enclosed/sass/general_enclosed_foundicons_ie7.scss
@@ -1,7 +1,7 @@
 @import "settings";
 
 /* general icons for IE7 */
-[class*="#{$classPrefix}"] {
+[class*="general-enclosed #{$classPrefix}"] {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons.css
+++ b/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons.css
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="general-enclosed foundicon-"]:before {
   font-family: "GeneralEnclosedFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons_ie7.css
+++ b/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons_ie7.css
@@ -1,5 +1,5 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="general-enclosed foundicon-"] {
   font-family: "GeneralEnclosedFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_social/demo.html
+++ b/foundation_icons_social/demo.html
@@ -87,41 +87,41 @@
     <div class="row">
 
       <ul class="four columns">
-        <li><i class="foundicon-thumb-up"></i></li>
-        <li><i class="foundicon-thumb-down"></i></li>
-        <li><i class="foundicon-rss"></i></li>
-        <li><i class="foundicon-facebook"></i></li>
-        <li><i class="foundicon-twitter"></i></li>
-        <li><i class="foundicon-pinterest"></i></li>
-        <li><i class="foundicon-github"></i></li>
-        <li><i class="foundicon-path"></i></li>
-        <li><i class="foundicon-linkedin"></i></li>
-        <li><i class="foundicon-dribbble"></i></li>
+        <li><i class="social foundicon-thumb-up"></i></li>
+        <li><i class="social foundicon-thumb-down"></i></li>
+        <li><i class="social foundicon-rss"></i></li>
+        <li><i class="social foundicon-facebook"></i></li>
+        <li><i class="social foundicon-twitter"></i></li>
+        <li><i class="social foundicon-pinterest"></i></li>
+        <li><i class="social foundicon-github"></i></li>
+        <li><i class="social foundicon-path"></i></li>
+        <li><i class="social foundicon-linkedin"></i></li>
+        <li><i class="social foundicon-dribbble"></i></li>
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-stumble-upon"></i></li>
-        <li><i class="foundicon-behance"></i></li>
-        <li><i class="foundicon-reddit"></i></li>
-        <li><i class="foundicon-google-plus"></i></li>
-        <li><i class="foundicon-youtube"></i></li>
-        <li><i class="foundicon-vimeo"></i></li>
-        <li><i class="foundicon-flickr"></i></li>
-        <li><i class="foundicon-slideshare"></i></li>
-        <li><i class="foundicon-picassa"></i></li>
-        <li><i class="foundicon-skype"></i></li>
+        <li><i class="social foundicon-stumble-upon"></i></li>
+        <li><i class="social foundicon-behance"></i></li>
+        <li><i class="social foundicon-reddit"></i></li>
+        <li><i class="social foundicon-google-plus"></i></li>
+        <li><i class="social foundicon-youtube"></i></li>
+        <li><i class="social foundicon-vimeo"></i></li>
+        <li><i class="social foundicon-flickr"></i></li>
+        <li><i class="social foundicon-slideshare"></i></li>
+        <li><i class="social foundicon-picassa"></i></li>
+        <li><i class="social foundicon-skype"></i></li>
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-instagram"></i></li>
-        <li><i class="foundicon-foursquare"></i></li>
-        <li><i class="foundicon-delicious"></i></li>
-        <li><i class="foundicon-chat"></i></li>
-        <li><i class="foundicon-torso"></i></li>
-        <li><i class="foundicon-tumblr"></i></li>
-        <li><i class="foundicon-video-chat"></i></li>
-        <li><i class="foundicon-digg"></i></li>
-        <li><i class="foundicon-wordpress"></i></li>
+        <li><i class="social foundicon-instagram"></i></li>
+        <li><i class="social foundicon-foursquare"></i></li>
+        <li><i class="social foundicon-delicious"></i></li>
+        <li><i class="social foundicon-chat"></i></li>
+        <li><i class="social foundicon-torso"></i></li>
+        <li><i class="social foundicon-tumblr"></i></li>
+        <li><i class="social foundicon-video-chat"></i></li>
+        <li><i class="social foundicon-digg"></i></li>
+        <li><i class="social foundicon-wordpress"></i></li>
       </ul>
 
     </div>

--- a/foundation_icons_social/sass/social_foundicons.scss
+++ b/foundation_icons_social/sass/social_foundicons.scss
@@ -14,7 +14,7 @@
   background-position: 0 0;
   background-repeat: repeat;
 }
-[class*="#{$classPrefix}"]:before {
+[class*="social #{$classPrefix}"]:before {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_social/sass/social_foundicons_ie7.scss
+++ b/foundation_icons_social/sass/social_foundicons_ie7.scss
@@ -1,7 +1,7 @@
 @import "settings";
 
 /* general icons for IE7 */
-[class*="#{$classPrefix}"] {
+[class*="social #{$classPrefix}"] {
   font-family: $fontName;
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_social/stylesheets/social_foundicons.css
+++ b/foundation_icons_social/stylesheets/social_foundicons.css
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="social foundicon-"]:before {
   font-family: "SocialFoundicons";
   font-weight: normal;
   font-style: normal;

--- a/foundation_icons_social/stylesheets/social_foundicons_ie7.css
+++ b/foundation_icons_social/stylesheets/social_foundicons_ie7.css
@@ -1,5 +1,5 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="social foundicon-"] {
   font-family: "SocialFoundicons";
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
Fixed the conflict when using multiple icon fonts by adding a prefix class in each one of them.
Those prefixes are:
- accessibility
- general
- general-enclosed
- social
