### PR TITLE
Change Prefixes .foundicon-[icon] to .foundicon-[set]-[icon] in order to use more than 1 set in the same project.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Usage
 =====
 * Download the icon font that you're interested in.
 * Merge the `fonts` and `stylesheets`, or `sass` if you are using it, folders into your Foundation project.
-* The default code is `<i class="foundicon-[icon]"></i>`, feel free to customize that to your needs.
+* The default code is `<i class="foundicon-[set]-[icon]"></i>`, feel free to customize that to your needs.
 * Style the icons using any CSS style that could apply to text!
 
 Repo Contents

--- a/foundation_icons_accessibility/demo.html
+++ b/foundation_icons_accessibility/demo.html
@@ -34,32 +34,32 @@
 
     [class*="foundicon-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
 
-    .foundicon-wheelchair:after         { content: "wheelchair"; }
-    .foundicon-speaker:after            { content: "speaker"; }
-    .foundicon-fontsize:after           { content: "fontsize"; }
-    .foundicon-eject:after              { content: "eject"; }
-    .foundicon-view-mode:after          { content: "view-mode"; }
-    .foundicon-eyeball:after            { content: "eyeball"; }
-    .foundicon-asl:after                { content: "asl"; }
-    .foundicon-person:after             { content: "person"; }
-    .foundicon-question:after           { content: "question"; }
-    .foundicon-adult:after              { content: "adult"; }
-    .foundicon-child:after              { content: "child"; }
-    .foundicon-glasses:after            { content: "glasses"; }
-    .foundicon-cc:after                 { content: "cc"; }
-    .foundicon-blind:after              { content: "blind"; }
-    .foundicon-braille:after            { content: "Braille"; }
-    .foundicon-iphone-home:after        { content: "iphone-home"; }
-    .foundicon-w3c:after                { content: "w3c"; }
-    .foundicon-css:after                { content: "css"; }
-    .foundicon-key:after                { content: "key"; }
-    .foundicon-hearing-impaired:after   { content: "hearing-impaired"; }
-    .foundicon-male:after               { content: "male"; }
-    .foundicon-female:after             { content: "female"; }
-    .foundicon-network:after            { content: "network"; }
-    .foundicon-guidedog:after           { content: "guidedog"; }
-    .foundicon-universal-access:after   { content: "universal-access"; }
-    .foundicon-elevator:after           { content: "elevator"; }
+    .foundicon-accessibility-wheelchair:after         { content: "wheelchair"; }
+    .foundicon-accessibility-speaker:after            { content: "speaker"; }
+    .foundicon-accessibility-fontsize:after           { content: "fontsize"; }
+    .foundicon-accessibility-eject:after              { content: "eject"; }
+    .foundicon-accessibility-view-mode:after          { content: "view-mode"; }
+    .foundicon-accessibility-eyeball:after            { content: "eyeball"; }
+    .foundicon-accessibility-asl:after                { content: "asl"; }
+    .foundicon-accessibility-person:after             { content: "person"; }
+    .foundicon-accessibility-question:after           { content: "question"; }
+    .foundicon-accessibility-adult:after              { content: "adult"; }
+    .foundicon-accessibility-child:after              { content: "child"; }
+    .foundicon-accessibility-glasses:after            { content: "glasses"; }
+    .foundicon-accessibility-cc:after                 { content: "cc"; }
+    .foundicon-accessibility-blind:after              { content: "blind"; }
+    .foundicon-accessibility-braille:after            { content: "Braille"; }
+    .foundicon-accessibility-iphone-home:after        { content: "iphone-home"; }
+    .foundicon-accessibility-w3c:after                { content: "w3c"; }
+    .foundicon-accessibility-css:after                { content: "css"; }
+    .foundicon-accessibility-key:after                { content: "key"; }
+    .foundicon-accessibility-hearing-impaired:after   { content: "hearing-impaired"; }
+    .foundicon-accessibility-male:after               { content: "male"; }
+    .foundicon-accessibility-female:after             { content: "female"; }
+    .foundicon-accessibility-network:after            { content: "network"; }
+    .foundicon-accessibility-guidedog:after           { content: "guidedog"; }
+    .foundicon-accessibility-universal-access:after   { content: "universal-access"; }
+    .foundicon-accessibility-elevator:after           { content: "elevator"; }
 
   </style>
 
@@ -82,29 +82,29 @@
     <div class="row">
 
       <ul class="four columns">
-        <li><i class="foundicon-wheelchair"></i></li>
-        <li><i class="foundicon-speaker"></i></li>
-        <li><i class="foundicon-fontsize"></i></li>
-        <li><i class="foundicon-eject"></i></li>
-        <li><i class="foundicon-view-mode"></i></li>
-        <li><i class="foundicon-eyeball"></i></li>
+        <li><i class="foundicon-accessibility-wheelchair"></i></li>
+        <li><i class="foundicon-accessibility-speaker"></i></li>
+        <li><i class="foundicon-accessibility-fontsize"></i></li>
+        <li><i class="foundicon-accessibility-eject"></i></li>
+        <li><i class="foundicon-accessibility-view-mode"></i></li>
+        <li><i class="foundicon-accessibility-eyeball"></i></li>
 
-        <li><i class="foundicon-asl"></i></li>
-        <li><i class="foundicon-person"></i></li>
-        <li><i class="foundicon-question"></i></li>
+        <li><i class="foundicon-accessibility-asl"></i></li>
+        <li><i class="foundicon-accessibility-person"></i></li>
+        <li><i class="foundicon-accessibility-question"></i></li>
         
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-adult"></i></li>
-        <li><i class="foundicon-child"></i></li>
-        <li><i class="foundicon-glasses"></i></li>
-        <li><i class="foundicon-cc"></i></li>
-        <li><i class="foundicon-blind"></i></li>
-        <li><i class="foundicon-braille"></i></li>
-        <li><i class="foundicon-iphone-home"></i></li>
-        <li><i class="foundicon-w3c"></i></li>
-        <li><i class="foundicon-css"></i></li>
+        <li><i class="foundicon-accessibility-adult"></i></li>
+        <li><i class="foundicon-accessibility-child"></i></li>
+        <li><i class="foundicon-accessibility-glasses"></i></li>
+        <li><i class="foundicon-accessibility-cc"></i></li>
+        <li><i class="foundicon-accessibility-blind"></i></li>
+        <li><i class="foundicon-accessibility-braille"></i></li>
+        <li><i class="foundicon-accessibility-iphone-home"></i></li>
+        <li><i class="foundicon-accessibility-w3c"></i></li>
+        <li><i class="foundicon-accessibility-css"></i></li>
 
         
         
@@ -112,14 +112,14 @@
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-key"></i></li>
-        <li><i class="foundicon-hearing-impaired"></i></li>
-        <li><i class="foundicon-male"></i></li>
-        <li><i class="foundicon-female"></i></li>
-        <li><i class="foundicon-network"></i></li>
-        <li><i class="foundicon-guidedog"></i></li>
-        <li><i class="foundicon-universal-access"></i></li>
-        <li><i class="foundicon-elevator"></i></li>
+        <li><i class="foundicon-accessibility-key"></i></li>
+        <li><i class="foundicon-accessibility-hearing-impaired"></i></li>
+        <li><i class="foundicon-accessibility-male"></i></li>
+        <li><i class="foundicon-accessibility-female"></i></li>
+        <li><i class="foundicon-accessibility-network"></i></li>
+        <li><i class="foundicon-accessibility-guidedog"></i></li>
+        <li><i class="foundicon-accessibility-universal-access"></i></li>
+        <li><i class="foundicon-accessibility-elevator"></i></li>
       </ul>
 
     </div>
@@ -129,7 +129,7 @@
         <h4>Here's the code:</h4>
         <div class="code">
 <pre>
-&lt;i class="<span class="class">foundicon-[icon]</span>"&gt;&lt;/i&gt;
+&lt;i class="<span class="class">foundicon-accessibility-[icon]</span>"&gt;&lt;/i&gt;
 </pre>
         </div>
       </div>

--- a/foundation_icons_accessibility/sass/_settings.scss
+++ b/foundation_icons_accessibility/sass/_settings.scss
@@ -1,6 +1,6 @@
 $fontFileName: "../fonts/accessibility_foundicons";
 $fontName: "AccessibilityFoundicons";
-$classPrefix: "foundicon-";
+$classPrefix: "foundicon-accessibility-";
 
 @mixin i-class($name,$pua) {
   .#{$classPrefix}#{$name}:before { 

--- a/foundation_icons_accessibility/stylesheets/accessibility_foundicons.css
+++ b/foundation_icons_accessibility/stylesheets/accessibility_foundicons.css
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="foundicon-accessibility-"]:before {
   font-family: "AccessibilityFoundicons";
   font-weight: normal;
   font-style: normal;
@@ -27,106 +27,106 @@
 }
 
 /* icons */
-.foundicon-wheelchair:before {
+.foundicon-accessibility-wheelchair:before {
   content: "\f000";
 }
 
-.foundicon-speaker:before {
+.foundicon-accessibility-speaker:before {
   content: "\f001";
 }
 
-.foundicon-fontsize:before {
+.foundicon-accessibility-fontsize:before {
   content: "\f002";
 }
 
-.foundicon-eject:before {
+.foundicon-accessibility-eject:before {
   content: "\f003";
 }
 
-.foundicon-view-mode:before {
+.foundicon-accessibility-view-mode:before {
   content: "\f004";
 }
 
-.foundicon-eyeball:before {
+.foundicon-accessibility-eyeball:before {
   content: "\f005";
 }
 
-.foundicon-asl:before {
+.foundicon-accessibility-asl:before {
   content: "\f006";
 }
 
-.foundicon-person:before {
+.foundicon-accessibility-person:before {
   content: "\f007";
 }
 
-.foundicon-question:before {
+.foundicon-accessibility-question:before {
   content: "\f008";
 }
 
-.foundicon-adult:before {
+.foundicon-accessibility-adult:before {
   content: "\f009";
 }
 
-.foundicon-child:before {
+.foundicon-accessibility-child:before {
   content: "\f00a";
 }
 
-.foundicon-glasses:before {
+.foundicon-accessibility-glasses:before {
   content: "\f00b";
 }
 
-.foundicon-cc:before {
+.foundicon-accessibility-cc:before {
   content: "\f00c";
 }
 
-.foundicon-blind:before {
+.foundicon-accessibility-blind:before {
   content: "\f00d";
 }
 
-.foundicon-braille:before {
+.foundicon-accessibility-braille:before {
   content: "\f00e";
 }
 
-.foundicon-iphone-home:before {
+.foundicon-accessibility-iphone-home:before {
   content: "\f00f";
 }
 
-.foundicon-w3c:before {
+.foundicon-accessibility-w3c:before {
   content: "\f010";
 }
 
-.foundicon-css:before {
+.foundicon-accessibility-css:before {
   content: "\f011";
 }
 
-.foundicon-key:before {
+.foundicon-accessibility-key:before {
   content: "\f012";
 }
 
-.foundicon-hearing-impaired:before {
+.foundicon-accessibility-hearing-impaired:before {
   content: "\f013";
 }
 
-.foundicon-male:before {
+.foundicon-accessibility-male:before {
   content: "\f014";
 }
 
-.foundicon-female:before {
+.foundicon-accessibility-female:before {
   content: "\f015";
 }
 
-.foundicon-network:before {
+.foundicon-accessibility-network:before {
   content: "\f016";
 }
 
-.foundicon-guidedog:before {
+.foundicon-accessibility-guidedog:before {
   content: "\f017";
 }
 
-.foundicon-universal-access:before {
+.foundicon-accessibility-universal-access:before {
   content: "\f018";
 }
 
-.foundicon-elevator:before {
+.foundicon-accessibility-elevator:before {
   content: "\f019";
 }

--- a/foundation_icons_accessibility/stylesheets/accessibility_foundicons_ie7.css
+++ b/foundation_icons_accessibility/stylesheets/accessibility_foundicons_ie7.css
@@ -1,110 +1,110 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="foundicon-accessibility-accessibility-"] {
   font-family: "AccessibilityFoundicons";
   font-weight: normal;
   font-style: normal;
 }
 
-.foundicon-wheelchair {
+.foundicon-accessibility-wheelchair {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf000;");
 }
 
-.foundicon-speaker {
+.foundicon-accessibility-speaker {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf001;");
 }
 
-.foundicon-fontsize {
+.foundicon-accessibility-fontsize {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf002;");
 }
 
-.foundicon-eject {
+.foundicon-accessibility-eject {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf003;");
 }
 
-.foundicon-view-mode {
+.foundicon-accessibility-view-mode {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf004;");
 }
 
-.foundicon-eyeball {
+.foundicon-accessibility-eyeball {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf005;");
 }
 
-.foundicon-asl {
+.foundicon-accessibility-asl {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf006;");
 }
 
-.foundicon-person {
+.foundicon-accessibility-person {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf007;");
 }
 
-.foundicon-question {
+.foundicon-accessibility-question {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf008;");
 }
 
-.foundicon-adult {
+.foundicon-accessibility-adult {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf009;");
 }
 
-.foundicon-child {
+.foundicon-accessibility-child {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00a;");
 }
 
-.foundicon-glasses {
+.foundicon-accessibility-glasses {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00b;");
 }
 
-.foundicon-cc {
+.foundicon-accessibility-cc {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00c;");
 }
 
-.foundicon-blind {
+.foundicon-accessibility-blind {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00d;");
 }
 
-.foundicon-braille {
+.foundicon-accessibility-braille {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00e;");
 }
 
-.foundicon-iphone-home {
+.foundicon-accessibility-iphone-home {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00f;");
 }
 
-.foundicon-w3c {
+.foundicon-accessibility-w3c {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf010;");
 }
 
-.foundicon-css {
+.foundicon-accessibility-css {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf011;");
 }
 
-.foundicon-key {
+.foundicon-accessibility-key {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf012;");
 }
 
-.foundicon-hearing-impaired {
+.foundicon-accessibility-hearing-impaired {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf013;");
 }
 
-.foundicon-male {
+.foundicon-accessibility-male {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf014;");
 }
 
-.foundicon-female {
+.foundicon-accessibility-female {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf015;");
 }
 
-.foundicon-network {
+.foundicon-accessibility-network {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf016;");
 }
 
-.foundicon-guidedog {
+.foundicon-accessibility-guidedog {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf017;");
 }
 
-.foundicon-universal-access {
+.foundicon-accessibility-universal-access {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf018;");
 }
 
-.foundicon-elevator {
+.foundicon-accessibility-elevator {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf019;");
 }

--- a/foundation_icons_general/demo.html
+++ b/foundation_icons_general/demo.html
@@ -31,62 +31,62 @@
     .class { color: #4DB9EE; }
     em { color: #aaa; }
 
-    [class*="foundicon-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
+    [class*="foundicon-general-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
 
-    .foundicon-settings:after        { content: "settings"; }
-    .foundicon-heart:after           { content: "heart"; }
-    .foundicon-star:after            { content: "star"; }
-    .foundicon-plus:after            { content: "plus"; }
-    .foundicon-minus:after           { content: "minus"; }
-    .foundicon-checkmark:after       { content: "checkmark"; }
+    .foundicon-general-settings:after        { content: "settings"; }
+    .foundicon-general-heart:after           { content: "heart"; }
+    .foundicon-general-star:after            { content: "star"; }
+    .foundicon-general-plus:after            { content: "plus"; }
+    .foundicon-general-minus:after           { content: "minus"; }
+    .foundicon-general-checkmark:after       { content: "checkmark"; }
 
-    .foundicon-remove:after          { content: "remove"; }
-    .foundicon-mail:after            { content: "mail"; }
-    .foundicon-calendar:after        { content: "calendar"; }
-    .foundicon-page:after            { content: "page"; }
-    .foundicon-tools:after           { content: "tools"; }
-    .foundicon-globe:after           { content: "globe"; }
+    .foundicon-general-remove:after          { content: "remove"; }
+    .foundicon-general-mail:after            { content: "mail"; }
+    .foundicon-general-calendar:after        { content: "calendar"; }
+    .foundicon-general-page:after            { content: "page"; }
+    .foundicon-general-tools:after           { content: "tools"; }
+    .foundicon-general-globe:after           { content: "globe"; }
 
-    .foundicon-home:after            { content: "home"; }
-    .foundicon-quote:after           { content: "quote"; }
-    .foundicon-people:after          { content: "people"; }
-    .foundicon-monitor:after         { content: "monitor"; }
-    .foundicon-laptop:after          { content: "laptop"; }
-    .foundicon-phone:after           { content: "phone"; }
+    .foundicon-general-home:after            { content: "home"; }
+    .foundicon-general-quote:after           { content: "quote"; }
+    .foundicon-general-people:after          { content: "people"; }
+    .foundicon-general-monitor:after         { content: "monitor"; }
+    .foundicon-general-laptop:after          { content: "laptop"; }
+    .foundicon-general-phone:after           { content: "phone"; }
 
-    .foundicon-cloud:after           { content: "cloud"; }
-    .foundicon-error:after           { content: "error"; }
-    .foundicon-right-arrow:after     { content: "right-arrow"; }
-    .foundicon-left-arrow:after      { content: "left-arrow"; }
-    .foundicon-up-arrow:after        { content: "up-arrow"; }
-    .foundicon-down-arrow:after      { content: "down-arrow"; }
+    .foundicon-general-cloud:after           { content: "cloud"; }
+    .foundicon-general-error:after           { content: "error"; }
+    .foundicon-general-right-arrow:after     { content: "right-arrow"; }
+    .foundicon-general-left-arrow:after      { content: "left-arrow"; }
+    .foundicon-general-up-arrow:after        { content: "up-arrow"; }
+    .foundicon-general-down-arrow:after      { content: "down-arrow"; }
 
-    .foundicon-trash:after           { content: "trash"; }
-    .foundicon-add-doc:after         { content: "add-doc"; }
-    .foundicon-edit:after            { content: "edit"; }
-    .foundicon-lock:after            { content: "lock"; }
-    .foundicon-unlock:after          { content: "unlock"; }
-    .foundicon-refresh:after         { content: "refresh"; }
+    .foundicon-general-trash:after           { content: "trash"; }
+    .foundicon-general-add-doc:after         { content: "add-doc"; }
+    .foundicon-general-edit:after            { content: "edit"; }
+    .foundicon-general-lock:after            { content: "lock"; }
+    .foundicon-general-unlock:after          { content: "unlock"; }
+    .foundicon-general-refresh:after         { content: "refresh"; }
 
-    .foundicon-paper-clip:after      { content: "paper-clip"; }
-    .foundicon-video:after           { content: "video"; }
-    .foundicon-photo:after           { content: "photo"; }
-    .foundicon-graph:after           { content: "graph"; }
-    .foundicon-idea:after            { content: "idea"; }
-    .foundicon-mic:after             { content: "mic"; }
+    .foundicon-general-paper-clip:after      { content: "paper-clip"; }
+    .foundicon-general-video:after           { content: "video"; }
+    .foundicon-general-photo:after           { content: "photo"; }
+    .foundicon-general-graph:after           { content: "graph"; }
+    .foundicon-general-idea:after            { content: "idea"; }
+    .foundicon-general-mic:after             { content: "mic"; }
 
-    .foundicon-cart:after            { content: "cart"; }
-    .foundicon-address-book:after    { content: "address-book"; }
-    .foundicon-compass:after         { content: "compass"; }
-    .foundicon-flag:after            { content: "flag"; }
-    .foundicon-location:after        { content: "location"; }
-    .foundicon-clock:after           { content: "clock"; }
+    .foundicon-general-cart:after            { content: "cart"; }
+    .foundicon-general-address-book:after    { content: "address-book"; }
+    .foundicon-general-compass:after         { content: "compass"; }
+    .foundicon-general-flag:after            { content: "flag"; }
+    .foundicon-general-location:after        { content: "location"; }
+    .foundicon-general-clock:after           { content: "clock"; }
 
-    .foundicon-folder:after          { content: "folder"; }
-    .foundicon-inbox:after           { content: "inbox"; }
-    .foundicon-website:after         { content: "website"; }
-    .foundicon-smiley:after          { content: "smiley"; }
-    .foundicon-search:after          { content: "search"; }
+    .foundicon-general-folder:after          { content: "folder"; }
+    .foundicon-general-inbox:after           { content: "inbox"; }
+    .foundicon-general-website:after         { content: "website"; }
+    .foundicon-general-smiley:after          { content: "smiley"; }
+    .foundicon-general-search:after          { content: "search"; }
 
   </style>
 
@@ -110,66 +110,66 @@
     <div class="row">
 
       <ul class="three columns">
-        <li><i class="button foundicon-settings"></i></li>
-        <li><i class="foundicon-heart"></i></li>
-        <li><i class="foundicon-star"></i></li>
-        <li><i class="foundicon-plus"></i></li>
-        <li><i class="foundicon-minus"></i></li>
-        <li class="last-in-row"><i class="foundicon-checkmark"></i></li>
+        <li><i class="button foundicon-general-settings"></i></li>
+        <li><i class="foundicon-general-heart"></i></li>
+        <li><i class="foundicon-general-star"></i></li>
+        <li><i class="foundicon-general-plus"></i></li>
+        <li><i class="foundicon-general-minus"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-checkmark"></i></li>
 
-        <li><i class="foundicon-remove"></i></li>
-        <li><i class="foundicon-mail"></i></li>
-        <li><i class="foundicon-calendar"></i></li>
-        <li><i class="foundicon-page"></i></li>
-        <li><i class="foundicon-tools"></i></li>
-        <li class="last-in-row"><i class="foundicon-globe"></i></li>
+        <li><i class="foundicon-general-remove"></i></li>
+        <li><i class="foundicon-general-mail"></i></li>
+        <li><i class="foundicon-general-calendar"></i></li>
+        <li><i class="foundicon-general-page"></i></li>
+        <li><i class="foundicon-general-tools"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-globe"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-home"></i></li>
-        <li><i class="foundicon-quote"></i></li>
-        <li><i class="foundicon-people"></i></li>
-        <li><i class="foundicon-monitor"></i></li>
-        <li><i class="foundicon-laptop"></i></li>
-        <li class="last-in-row"><i class="foundicon-phone"></i></li>
+        <li><i class="foundicon-general-home"></i></li>
+        <li><i class="foundicon-general-quote"></i></li>
+        <li><i class="foundicon-general-people"></i></li>
+        <li><i class="foundicon-general-monitor"></i></li>
+        <li><i class="foundicon-general-laptop"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-phone"></i></li>
 
-        <li><i class="foundicon-cloud"></i></li>
-        <li><i class="foundicon-error"></i></li>
-        <li><i class="foundicon-right-arrow"></i></li>
-        <li><i class="foundicon-left-arrow"></i></li>
-        <li><i class="foundicon-up-arrow"></i></li>
-        <li class="last-in-row"><i class="foundicon-down-arrow"></i></li>
+        <li><i class="foundicon-general-cloud"></i></li>
+        <li><i class="foundicon-general-error"></i></li>
+        <li><i class="foundicon-general-right-arrow"></i></li>
+        <li><i class="foundicon-general-left-arrow"></i></li>
+        <li><i class="foundicon-general-up-arrow"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-down-arrow"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-trash"></i></li>
-        <li><i class="foundicon-add-doc"></i></li>
-        <li><i class="foundicon-edit"></i></li>
-        <li><i class="foundicon-lock"></i></li>
-        <li><i class="foundicon-unlock"></i></li>
-        <li class="last-in-row"><i class="foundicon-refresh"></i></li>
+        <li><i class="foundicon-general-trash"></i></li>
+        <li><i class="foundicon-general-add-doc"></i></li>
+        <li><i class="foundicon-general-edit"></i></li>
+        <li><i class="foundicon-general-lock"></i></li>
+        <li><i class="foundicon-general-unlock"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-refresh"></i></li>
 
-        <li><i class="foundicon-paper-clip"></i></li>
-        <li><i class="foundicon-video"></i></li>
-        <li><i class="foundicon-photo"></i></li>
-        <li><i class="foundicon-graph"></i></li>
-        <li><i class="foundicon-idea"></i></li>
-        <li class="last-in-row"><i class="foundicon-mic"></i></li>
+        <li><i class="foundicon-general-paper-clip"></i></li>
+        <li><i class="foundicon-general-video"></i></li>
+        <li><i class="foundicon-general-photo"></i></li>
+        <li><i class="foundicon-general-graph"></i></li>
+        <li><i class="foundicon-general-idea"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-mic"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-cart"></i></li>
-        <li><i class="foundicon-address-book"></i></li>
-        <li><i class="foundicon-compass"></i></li>
-        <li><i class="foundicon-flag"></i></li>
-        <li><i class="foundicon-location"></i></li>
-        <li class="last-in-row"><i class="foundicon-clock"></i></li>
+        <li><i class="foundicon-general-cart"></i></li>
+        <li><i class="foundicon-general-address-book"></i></li>
+        <li><i class="foundicon-general-compass"></i></li>
+        <li><i class="foundicon-general-flag"></i></li>
+        <li><i class="foundicon-general-location"></i></li>
+        <li class="last-in-row"><i class="foundicon-general-clock"></i></li>
 
-        <li><i class="foundicon-folder"></i></li>
-        <li><i class="foundicon-inbox"></i></li>
-        <li><i class="foundicon-website"></i></li>
-        <li><i class="foundicon-smiley"></i></li>
-        <li><i class="foundicon-search"></i></li>
+        <li><i class="foundicon-general-folder"></i></li>
+        <li><i class="foundicon-general-inbox"></i></li>
+        <li><i class="foundicon-general-website"></i></li>
+        <li><i class="foundicon-general-smiley"></i></li>
+        <li><i class="foundicon-general-search"></i></li>
       </ul>
 
     </div>
@@ -179,7 +179,7 @@
         <h4>Here's the code:</h4>
         <div class="code">
 <pre>
-&lt;i class="<span class="class">foundicon-[icon]</span>"&gt;&lt;/i&gt;
+&lt;i class="<span class="class">foundicon-general-[icon]</span>"&gt;&lt;/i&gt;
 </pre>
         </div>
       </div>

--- a/foundation_icons_general/sass/_settings.scss
+++ b/foundation_icons_general/sass/_settings.scss
@@ -1,6 +1,6 @@
 $fontFileName: "../fonts/general_foundicons";
 $fontName: "GeneralFoundicons";
-$classPrefix: "foundicon-";
+$classPrefix: "general-foundicon-";
 
 @mixin i-class($name,$pua) {
   .#{$classPrefix}#{$name}:before { 

--- a/foundation_icons_general/sass/_settings.scss
+++ b/foundation_icons_general/sass/_settings.scss
@@ -1,6 +1,6 @@
 $fontFileName: "../fonts/general_foundicons";
 $fontName: "GeneralFoundicons";
-$classPrefix: "general-foundicon-";
+$classPrefix: "foundicon-general-";
 
 @mixin i-class($name,$pua) {
   .#{$classPrefix}#{$name}:before { 

--- a/foundation_icons_general/stylesheets/general_foundicons.css
+++ b/foundation_icons_general/stylesheets/general_foundicons.css
@@ -8,7 +8,7 @@
 }
 
 /* global foundicon styles */
-[class*="foundicon-"] {
+[class*="foundicon-general-"] {
   display: inline;
   width: auto;
   height: auto;
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="foundicon-general-"]:before {
   font-family: "GeneralFoundicons";
   font-weight: normal;
   font-style: normal;
@@ -27,190 +27,190 @@
 }
 
 /* icons */
-.foundicon-settings:before {
+.foundicon-general-settings:before {
   content: "\f000";
 }
 
-.foundicon-heart:before {
+.foundicon-general-heart:before {
   content: "\f001";
 }
 
-.foundicon-star:before {
+.foundicon-general-star:before {
   content: "\f002";
 }
 
-.foundicon-plus:before {
+.foundicon-general-plus:before {
   content: "\f003";
 }
 
-.foundicon-minus:before {
+.foundicon-general-minus:before {
   content: "\f004";
 }
 
-.foundicon-checkmark:before {
+.foundicon-general-checkmark:before {
   content: "\f005";
 }
 
-.foundicon-remove:before {
+.foundicon-general-remove:before {
   content: "\f006";
 }
 
-.foundicon-mail:before {
+.foundicon-general-mail:before {
   content: "\f007";
 }
 
-.foundicon-calendar:before {
+.foundicon-general-calendar:before {
   content: "\f008";
 }
 
-.foundicon-page:before {
+.foundicon-general-page:before {
   content: "\f009";
 }
 
-.foundicon-tools:before {
+.foundicon-general-tools:before {
   content: "\f00a";
 }
 
-.foundicon-globe:before {
+.foundicon-general-globe:before {
   content: "\f00b";
 }
 
-.foundicon-home:before {
+.foundicon-general-home:before {
   content: "\f00c";
 }
 
-.foundicon-quote:before {
+.foundicon-general-quote:before {
   content: "\f00d";
 }
 
-.foundicon-people:before {
+.foundicon-general-people:before {
   content: "\f00e";
 }
 
-.foundicon-monitor:before {
+.foundicon-general-monitor:before {
   content: "\f00f";
 }
 
-.foundicon-laptop:before {
+.foundicon-general-laptop:before {
   content: "\f010";
 }
 
-.foundicon-phone:before {
+.foundicon-general-phone:before {
   content: "\f011";
 }
 
-.foundicon-cloud:before {
+.foundicon-general-cloud:before {
   content: "\f012";
 }
 
-.foundicon-error:before {
+.foundicon-general-error:before {
   content: "\f013";
 }
 
-.foundicon-right-arrow:before {
+.foundicon-general-right-arrow:before {
   content: "\f014";
 }
 
-.foundicon-left-arrow:before {
+.foundicon-general-left-arrow:before {
   content: "\f015";
 }
 
-.foundicon-up-arrow:before {
+.foundicon-general-up-arrow:before {
   content: "\f016";
 }
 
-.foundicon-down-arrow:before {
+.foundicon-general-down-arrow:before {
   content: "\f017";
 }
 
-.foundicon-trash:before {
+.foundicon-general-trash:before {
   content: "\f018";
 }
 
-.foundicon-add-doc:before {
+.foundicon-general-add-doc:before {
   content: "\f019";
 }
 
-.foundicon-edit:before {
+.foundicon-general-edit:before {
   content: "\f01a";
 }
 
-.foundicon-lock:before {
+.foundicon-general-lock:before {
   content: "\f01b";
 }
 
-.foundicon-unlock:before {
+.foundicon-general-unlock:before {
   content: "\f01c";
 }
 
-.foundicon-refresh:before {
+.foundicon-general-refresh:before {
   content: "\f01d";
 }
 
-.foundicon-paper-clip:before {
+.foundicon-general-paper-clip:before {
   content: "\f01e";
 }
 
-.foundicon-video:before {
+.foundicon-general-video:before {
   content: "\f01f";
 }
 
-.foundicon-photo:before {
+.foundicon-general-photo:before {
   content: "\f020";
 }
 
-.foundicon-graph:before {
+.foundicon-general-graph:before {
   content: "\f021";
 }
 
-.foundicon-idea:before {
+.foundicon-general-idea:before {
   content: "\f022";
 }
 
-.foundicon-mic:before {
+.foundicon-general-mic:before {
   content: "\f023";
 }
 
-.foundicon-cart:before {
+.foundicon-general-cart:before {
   content: "\f024";
 }
 
-.foundicon-address-book:before {
+.foundicon-general-address-book:before {
   content: "\f025";
 }
 
-.foundicon-compass:before {
+.foundicon-general-compass:before {
   content: "\f026";
 }
 
-.foundicon-flag:before {
+.foundicon-general-flag:before {
   content: "\f027";
 }
 
-.foundicon-location:before {
+.foundicon-general-location:before {
   content: "\f028";
 }
 
-.foundicon-clock:before {
+.foundicon-general-clock:before {
   content: "\f029";
 }
 
-.foundicon-folder:before {
+.foundicon-general-folder:before {
   content: "\f02a";
 }
 
-.foundicon-inbox:before {
+.foundicon-general-inbox:before {
   content: "\f02b";
 }
 
-.foundicon-website:before {
+.foundicon-general-website:before {
   content: "\f02c";
 }
 
-.foundicon-smiley:before {
+.foundicon-general-smiley:before {
   content: "\f02d";
 }
 
-.foundicon-search:before {
+.foundicon-general-search:before {
   content: "\f02e";
 }

--- a/foundation_icons_general/stylesheets/general_foundicons_ie7.css
+++ b/foundation_icons_general/stylesheets/general_foundicons_ie7.css
@@ -1,194 +1,194 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="foundicon-general-"] {
   font-family: "GeneralFoundicons";
   font-weight: normal;
   font-style: normal;
 }
 
-.foundicon-settings {
+.foundicon-general-settings {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf000;");
 }
 
-.foundicon-heart {
+.foundicon-general-heart {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf001;");
 }
 
-.foundicon-star {
+.foundicon-general-star {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf002;");
 }
 
-.foundicon-plus {
+.foundicon-general-plus {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf003;");
 }
 
-.foundicon-minus {
+.foundicon-general-minus {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf004;");
 }
 
-.foundicon-checkmark {
+.foundicon-general-checkmark {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf005;");
 }
 
-.foundicon-remove {
+.foundicon-general-remove {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf006;");
 }
 
-.foundicon-mail {
+.foundicon-general-mail {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf007;");
 }
 
-.foundicon-calendar {
+.foundicon-general-calendar {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf008;");
 }
 
-.foundicon-page {
+.foundicon-general-page {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf009;");
 }
 
-.foundicon-tools {
+.foundicon-general-tools {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00a;");
 }
 
-.foundicon-globe {
+.foundicon-general-globe {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00b;");
 }
 
-.foundicon-home {
+.foundicon-general-home {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00c;");
 }
 
-.foundicon-quote {
+.foundicon-general-quote {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00d;");
 }
 
-.foundicon-people {
+.foundicon-general-people {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00e;");
 }
 
-.foundicon-monitor {
+.foundicon-general-monitor {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00f;");
 }
 
-.foundicon-laptop {
+.foundicon-general-laptop {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf010;");
 }
 
-.foundicon-phone {
+.foundicon-general-phone {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf011;");
 }
 
-.foundicon-cloud {
+.foundicon-general-cloud {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf012;");
 }
 
-.foundicon-error {
+.foundicon-general-error {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf013;");
 }
 
-.foundicon-right-arrow {
+.foundicon-general-right-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf014;");
 }
 
-.foundicon-left-arrow {
+.foundicon-general-left-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf015;");
 }
 
-.foundicon-up-arrow {
+.foundicon-general-up-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf016;");
 }
 
-.foundicon-down-arrow {
+.foundicon-general-down-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf017;");
 }
 
-.foundicon-trash {
+.foundicon-general-trash {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf018;");
 }
 
-.foundicon-add-doc {
+.foundicon-general-add-doc {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf019;");
 }
 
-.foundicon-edit {
+.foundicon-general-edit {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01a;");
 }
 
-.foundicon-lock {
+.foundicon-general-lock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01b;");
 }
 
-.foundicon-unlock {
+.foundicon-general-unlock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01c;");
 }
 
-.foundicon-refresh {
+.foundicon-general-refresh {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01d;");
 }
 
-.foundicon-paper-clip {
+.foundicon-general-paper-clip {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01e;");
 }
 
-.foundicon-video {
+.foundicon-general-video {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01f;");
 }
 
-.foundicon-photo {
+.foundicon-general-photo {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf020;");
 }
 
-.foundicon-graph {
+.foundicon-general-graph {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf021;");
 }
 
-.foundicon-idea {
+.foundicon-general-idea {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf022;");
 }
 
-.foundicon-mic {
+.foundicon-general-mic {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf023;");
 }
 
-.foundicon-cart {
+.foundicon-general-cart {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf024;");
 }
 
-.foundicon-address-book {
+.foundicon-general-address-book {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf025;");
 }
 
-.foundicon-compass {
+.foundicon-general-compass {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf026;");
 }
 
-.foundicon-flag {
+.foundicon-general-flag {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf027;");
 }
 
-.foundicon-location {
+.foundicon-general-location {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf028;");
 }
 
-.foundicon-clock {
+.foundicon-general-clock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf029;");
 }
 
-.foundicon-folder {
+.foundicon-general-folder {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02a;");
 }
 
-.foundicon-inbox {
+.foundicon-general-inbox {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02b;");
 }
 
-.foundicon-website {
+.foundicon-general-website {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02c;");
 }
 
-.foundicon-smiley {
+.foundicon-general-smiley {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02d;");
 }
 
-.foundicon-search {
+.foundicon-general-search {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02e;");
 }

--- a/foundation_icons_general_enclosed/demo.html
+++ b/foundation_icons_general_enclosed/demo.html
@@ -32,62 +32,62 @@
     .class { color: #4DB9EE; }
     em { color: #aaa; }
 
-    [class*="foundicon-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
+    [class*="foundicon-enclosed-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
 
-    .foundicon-settings:after        { content: "settings"; }
-    .foundicon-heart:after           { content: "heart"; }
-    .foundicon-star:after            { content: "star"; }
-    .foundicon-plus:after            { content: "plus"; }
-    .foundicon-minus:after           { content: "minus"; }
-    .foundicon-checkmark:after       { content: "checkmark"; }
+    .foundicon-enclosed-settings:after        { content: "settings"; }
+    .foundicon-enclosed-heart:after           { content: "heart"; }
+    .foundicon-enclosed-star:after            { content: "star"; }
+    .foundicon-enclosed-plus:after            { content: "plus"; }
+    .foundicon-enclosed-minus:after           { content: "minus"; }
+    .foundicon-enclosed-checkmark:after       { content: "checkmark"; }
 
-    .foundicon-remove:after          { content: "remove"; }
-    .foundicon-mail:after            { content: "mail"; }
-    .foundicon-calendar:after        { content: "calendar"; }
-    .foundicon-page:after            { content: "page"; }
-    .foundicon-tools:after           { content: "tools"; }
-    .foundicon-globe:after           { content: "globe"; }
+    .foundicon-enclosed-remove:after          { content: "remove"; }
+    .foundicon-enclosed-mail:after            { content: "mail"; }
+    .foundicon-enclosed-calendar:after        { content: "calendar"; }
+    .foundicon-enclosed-page:after            { content: "page"; }
+    .foundicon-enclosed-tools:after           { content: "tools"; }
+    .foundicon-enclosed-globe:after           { content: "globe"; }
 
-    .foundicon-home:after            { content: "home"; }
-    .foundicon-quote:after           { content: "quote"; }
-    .foundicon-people:after          { content: "people"; }
-    .foundicon-monitor:after         { content: "monitor"; }
-    .foundicon-laptop:after          { content: "laptop"; }
-    .foundicon-phone:after           { content: "phone"; }
+    .foundicon-enclosed-home:after            { content: "home"; }
+    .foundicon-enclosed-quote:after           { content: "quote"; }
+    .foundicon-enclosed-people:after          { content: "people"; }
+    .foundicon-enclosed-monitor:after         { content: "monitor"; }
+    .foundicon-enclosed-laptop:after          { content: "laptop"; }
+    .foundicon-enclosed-phone:after           { content: "phone"; }
 
-    .foundicon-cloud:after           { content: "cloud"; }
-    .foundicon-error:after           { content: "error"; }
-    .foundicon-right-arrow:after     { content: "right-arrow"; }
-    .foundicon-left-arrow:after      { content: "left-arrow"; }
-    .foundicon-up-arrow:after        { content: "up-arrow"; }
-    .foundicon-down-arrow:after      { content: "down-arrow"; }
+    .foundicon-enclosed-cloud:after           { content: "cloud"; }
+    .foundicon-enclosed-error:after           { content: "error"; }
+    .foundicon-enclosed-right-arrow:after     { content: "right-arrow"; }
+    .foundicon-enclosed-left-arrow:after      { content: "left-arrow"; }
+    .foundicon-enclosed-up-arrow:after        { content: "up-arrow"; }
+    .foundicon-enclosed-down-arrow:after      { content: "down-arrow"; }
 
-    .foundicon-trash:after           { content: "trash"; }
-    .foundicon-add-doc:after         { content: "add-doc"; }
-    .foundicon-edit:after            { content: "edit"; }
-    .foundicon-lock:after            { content: "lock"; }
-    .foundicon-unlock:after          { content: "unlock"; }
-    .foundicon-refresh:after         { content: "refresh"; }
+    .foundicon-enclosed-trash:after           { content: "trash"; }
+    .foundicon-enclosed-add-doc:after         { content: "add-doc"; }
+    .foundicon-enclosed-edit:after            { content: "edit"; }
+    .foundicon-enclosed-lock:after            { content: "lock"; }
+    .foundicon-enclosed-unlock:after          { content: "unlock"; }
+    .foundicon-enclosed-refresh:after         { content: "refresh"; }
 
-    .foundicon-paper-clip:after      { content: "paper-clip"; }
-    .foundicon-video:after           { content: "video"; }
-    .foundicon-photo:after           { content: "photo"; }
-    .foundicon-graph:after           { content: "graph"; }
-    .foundicon-idea:after            { content: "idea"; }
-    .foundicon-mic:after             { content: "mic"; }
+    .foundicon-enclosed-paper-clip:after      { content: "paper-clip"; }
+    .foundicon-enclosed-video:after           { content: "video"; }
+    .foundicon-enclosed-photo:after           { content: "photo"; }
+    .foundicon-enclosed-graph:after           { content: "graph"; }
+    .foundicon-enclosed-idea:after            { content: "idea"; }
+    .foundicon-enclosed-mic:after             { content: "mic"; }
 
-    .foundicon-cart:after            { content: "cart"; }
-    .foundicon-address-book:after    { content: "address-book"; }
-    .foundicon-compass:after         { content: "compass"; }
-    .foundicon-flag:after            { content: "flag"; }
-    .foundicon-location:after        { content: "location"; }
-    .foundicon-clock:after           { content: "clock"; }
+    .foundicon-enclosed-cart:after            { content: "cart"; }
+    .foundicon-enclosed-address-book:after    { content: "address-book"; }
+    .foundicon-enclosed-compass:after         { content: "compass"; }
+    .foundicon-enclosed-flag:after            { content: "flag"; }
+    .foundicon-enclosed-location:after        { content: "location"; }
+    .foundicon-enclosed-clock:after           { content: "clock"; }
 
-    .foundicon-folder:after          { content: "folder"; }
-    .foundicon-inbox:after           { content: "inbox"; }
-    .foundicon-website:after         { content: "website"; }
-    .foundicon-smiley:after          { content: "smiley"; }
-    .foundicon-search:after          { content: "search"; }
+    .foundicon-enclosed-folder:after          { content: "folder"; }
+    .foundicon-enclosed-inbox:after           { content: "inbox"; }
+    .foundicon-enclosed-website:after         { content: "website"; }
+    .foundicon-enclosed-smiley:after          { content: "smiley"; }
+    .foundicon-enclosed-search:after          { content: "search"; }
 
   </style>
 
@@ -111,66 +111,66 @@
     <div class="row">
 
       <ul class="three columns">
-        <li><i class="button foundicon-settings"></i></li>
-        <li><i class="foundicon-heart"></i></li>
-        <li><i class="foundicon-star"></i></li>
-        <li><i class="foundicon-plus"></i></li>
-        <li><i class="foundicon-minus"></i></li>
-        <li class="last-in-row"><i class="foundicon-checkmark"></i></li>
+        <li><i class="button foundicon-enclosed-settings"></i></li>
+        <li><i class="foundicon-enclosed-heart"></i></li>
+        <li><i class="foundicon-enclosed-star"></i></li>
+        <li><i class="foundicon-enclosed-plus"></i></li>
+        <li><i class="foundicon-enclosed-minus"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-checkmark"></i></li>
 
-        <li><i class="foundicon-remove"></i></li>
-        <li><i class="foundicon-mail"></i></li>
-        <li><i class="foundicon-calendar"></i></li>
-        <li><i class="foundicon-page"></i></li>
-        <li><i class="foundicon-tools"></i></li>
-        <li class="last-in-row"><i class="foundicon-globe"></i></li>
+        <li><i class="foundicon-enclosed-remove"></i></li>
+        <li><i class="foundicon-enclosed-mail"></i></li>
+        <li><i class="foundicon-enclosed-calendar"></i></li>
+        <li><i class="foundicon-enclosed-page"></i></li>
+        <li><i class="foundicon-enclosed-tools"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-globe"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-home"></i></li>
-        <li><i class="foundicon-quote"></i></li>
-        <li><i class="foundicon-people"></i></li>
-        <li><i class="foundicon-monitor"></i></li>
-        <li><i class="foundicon-laptop"></i></li>
-        <li class="last-in-row"><i class="foundicon-phone"></i></li>
+        <li><i class="foundicon-enclosed-home"></i></li>
+        <li><i class="foundicon-enclosed-quote"></i></li>
+        <li><i class="foundicon-enclosed-people"></i></li>
+        <li><i class="foundicon-enclosed-monitor"></i></li>
+        <li><i class="foundicon-enclosed-laptop"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-phone"></i></li>
 
-        <li><i class="foundicon-cloud"></i></li>
-        <li><i class="foundicon-error"></i></li>
-        <li><i class="foundicon-right-arrow"></i></li>
-        <li><i class="foundicon-left-arrow"></i></li>
-        <li><i class="foundicon-up-arrow"></i></li>
-        <li class="last-in-row"><i class="foundicon-down-arrow"></i></li>
+        <li><i class="foundicon-enclosed-cloud"></i></li>
+        <li><i class="foundicon-enclosed-error"></i></li>
+        <li><i class="foundicon-enclosed-right-arrow"></i></li>
+        <li><i class="foundicon-enclosed-left-arrow"></i></li>
+        <li><i class="foundicon-enclosed-up-arrow"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-down-arrow"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-trash"></i></li>
-        <li><i class="foundicon-add-doc"></i></li>
-        <li><i class="foundicon-edit"></i></li>
-        <li><i class="foundicon-lock"></i></li>
-        <li><i class="foundicon-unlock"></i></li>
-        <li class="last-in-row"><i class="foundicon-refresh"></i></li>
+        <li><i class="foundicon-enclosed-trash"></i></li>
+        <li><i class="foundicon-enclosed-add-doc"></i></li>
+        <li><i class="foundicon-enclosed-edit"></i></li>
+        <li><i class="foundicon-enclosed-lock"></i></li>
+        <li><i class="foundicon-enclosed-unlock"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-refresh"></i></li>
 
-        <li><i class="foundicon-paper-clip"></i></li>
-        <li><i class="foundicon-video"></i></li>
-        <li><i class="foundicon-photo"></i></li>
-        <li><i class="foundicon-graph"></i></li>
-        <li><i class="foundicon-idea"></i></li>
-        <li class="last-in-row"><i class="foundicon-mic"></i></li>
+        <li><i class="foundicon-enclosed-paper-clip"></i></li>
+        <li><i class="foundicon-enclosed-video"></i></li>
+        <li><i class="foundicon-enclosed-photo"></i></li>
+        <li><i class="foundicon-enclosed-graph"></i></li>
+        <li><i class="foundicon-enclosed-idea"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-mic"></i></li>
       </ul>
 
       <ul class="three columns">
-        <li><i class="foundicon-cart"></i></li>
-        <li><i class="foundicon-address-book"></i></li>
-        <li><i class="foundicon-compass"></i></li>
-        <li><i class="foundicon-flag"></i></li>
-        <li><i class="foundicon-location"></i></li>
-        <li class="last-in-row"><i class="foundicon-clock"></i></li>
+        <li><i class="foundicon-enclosed-cart"></i></li>
+        <li><i class="foundicon-enclosed-address-book"></i></li>
+        <li><i class="foundicon-enclosed-compass"></i></li>
+        <li><i class="foundicon-enclosed-flag"></i></li>
+        <li><i class="foundicon-enclosed-location"></i></li>
+        <li class="last-in-row"><i class="foundicon-enclosed-clock"></i></li>
 
-        <li><i class="foundicon-folder"></i></li>
-        <li><i class="foundicon-inbox"></i></li>
-        <li><i class="foundicon-website"></i></li>
-        <li><i class="foundicon-smiley"></i></li>
-        <li><i class="foundicon-search"></i></li>
+        <li><i class="foundicon-enclosed-folder"></i></li>
+        <li><i class="foundicon-enclosed-inbox"></i></li>
+        <li><i class="foundicon-enclosed-website"></i></li>
+        <li><i class="foundicon-enclosed-smiley"></i></li>
+        <li><i class="foundicon-enclosed-search"></i></li>
       </ul>
 
     </div>
@@ -180,7 +180,7 @@
         <h4>Here's the code:</h4>
         <div class="code">
 <pre>
-&lt;i class="<span class="class">foundicon-[icon]</span>"&gt;&lt;/i&gt;
+&lt;i class="<span class="class">foundicon-enclosed-[icon]</span>"&gt;&lt;/i&gt;
 </pre>
         </div>
       </div>

--- a/foundation_icons_general_enclosed/sass/_settings.scss
+++ b/foundation_icons_general_enclosed/sass/_settings.scss
@@ -1,6 +1,6 @@
 $fontFileName: "../fonts/general_enclosed_foundicons";
 $fontName: "GeneralEnclosedFoundicons";
-$classPrefix: "foundicon-";
+$classPrefix: "foundicon-enclosed-";
 
 @mixin i-class($name,$pua) {
   .#{$classPrefix}#{$name}:before { 

--- a/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons.css
+++ b/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons.css
@@ -8,7 +8,7 @@
 }
 
 /* global foundicon styles */
-[class*="foundicon-"] {
+[class*="foundicon-enclosed-"] {
   display: inline;
   width: auto;
   height: auto;
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="foundicon-enclosed-"]:before {
   font-family: "GeneralEnclosedFoundicons";
   font-weight: normal;
   font-style: normal;
@@ -27,190 +27,190 @@
 }
 
 /* icons */
-.foundicon-settings:before {
+.foundicon-enclosed-settings:before {
   content: "\f000";
 }
 
-.foundicon-heart:before {
+.foundicon-enclosed-heart:before {
   content: "\f001";
 }
 
-.foundicon-star:before {
+.foundicon-enclosed-star:before {
   content: "\f002";
 }
 
-.foundicon-plus:before {
+.foundicon-enclosed-plus:before {
   content: "\f003";
 }
 
-.foundicon-minus:before {
+.foundicon-enclosed-minus:before {
   content: "\f004";
 }
 
-.foundicon-checkmark:before {
+.foundicon-enclosed-checkmark:before {
   content: "\f005";
 }
 
-.foundicon-remove:before {
+.foundicon-enclosed-remove:before {
   content: "\f006";
 }
 
-.foundicon-mail:before {
+.foundicon-enclosed-mail:before {
   content: "\f007";
 }
 
-.foundicon-calendar:before {
+.foundicon-enclosed-calendar:before {
   content: "\f008";
 }
 
-.foundicon-page:before {
+.foundicon-enclosed-page:before {
   content: "\f009";
 }
 
-.foundicon-tools:before {
+.foundicon-enclosed-tools:before {
   content: "\f00a";
 }
 
-.foundicon-globe:before {
+.foundicon-enclosed-globe:before {
   content: "\f00b";
 }
 
-.foundicon-home:before {
+.foundicon-enclosed-home:before {
   content: "\f00c";
 }
 
-.foundicon-quote:before {
+.foundicon-enclosed-quote:before {
   content: "\f00d";
 }
 
-.foundicon-people:before {
+.foundicon-enclosed-people:before {
   content: "\f00e";
 }
 
-.foundicon-monitor:before {
+.foundicon-enclosed-monitor:before {
   content: "\f00f";
 }
 
-.foundicon-laptop:before {
+.foundicon-enclosed-laptop:before {
   content: "\f010";
 }
 
-.foundicon-phone:before {
+.foundicon-enclosed-phone:before {
   content: "\f011";
 }
 
-.foundicon-cloud:before {
+.foundicon-enclosed-cloud:before {
   content: "\f012";
 }
 
-.foundicon-error:before {
+.foundicon-enclosed-error:before {
   content: "\f013";
 }
 
-.foundicon-right-arrow:before {
+.foundicon-enclosed-right-arrow:before {
   content: "\f014";
 }
 
-.foundicon-left-arrow:before {
+.foundicon-enclosed-left-arrow:before {
   content: "\f015";
 }
 
-.foundicon-up-arrow:before {
+.foundicon-enclosed-up-arrow:before {
   content: "\f016";
 }
 
-.foundicon-down-arrow:before {
+.foundicon-enclosed-down-arrow:before {
   content: "\f017";
 }
 
-.foundicon-trash:before {
+.foundicon-enclosed-trash:before {
   content: "\f018";
 }
 
-.foundicon-add-doc:before {
+.foundicon-enclosed-add-doc:before {
   content: "\f019";
 }
 
-.foundicon-edit:before {
+.foundicon-enclosed-edit:before {
   content: "\f01a";
 }
 
-.foundicon-lock:before {
+.foundicon-enclosed-lock:before {
   content: "\f01b";
 }
 
-.foundicon-unlock:before {
+.foundicon-enclosed-unlock:before {
   content: "\f01c";
 }
 
-.foundicon-refresh:before {
+.foundicon-enclosed-refresh:before {
   content: "\f01d";
 }
 
-.foundicon-paper-clip:before {
+.foundicon-enclosed-paper-clip:before {
   content: "\f01e";
 }
 
-.foundicon-video:before {
+.foundicon-enclosed-video:before {
   content: "\f01f";
 }
 
-.foundicon-photo:before {
+.foundicon-enclosed-photo:before {
   content: "\f020";
 }
 
-.foundicon-graph:before {
+.foundicon-enclosed-graph:before {
   content: "\f021";
 }
 
-.foundicon-idea:before {
+.foundicon-enclosed-idea:before {
   content: "\f022";
 }
 
-.foundicon-mic:before {
+.foundicon-enclosed-mic:before {
   content: "\f023";
 }
 
-.foundicon-cart:before {
+.foundicon-enclosed-cart:before {
   content: "\f024";
 }
 
-.foundicon-address-book:before {
+.foundicon-enclosed-address-book:before {
   content: "\f025";
 }
 
-.foundicon-compass:before {
+.foundicon-enclosed-compass:before {
   content: "\f026";
 }
 
-.foundicon-flag:before {
+.foundicon-enclosed-flag:before {
   content: "\f027";
 }
 
-.foundicon-location:before {
+.foundicon-enclosed-location:before {
   content: "\f028";
 }
 
-.foundicon-clock:before {
+.foundicon-enclosed-clock:before {
   content: "\f029";
 }
 
-.foundicon-folder:before {
+.foundicon-enclosed-folder:before {
   content: "\f02a";
 }
 
-.foundicon-inbox:before {
+.foundicon-enclosed-inbox:before {
   content: "\f02b";
 }
 
-.foundicon-website:before {
+.foundicon-enclosed-website:before {
   content: "\f02c";
 }
 
-.foundicon-smiley:before {
+.foundicon-enclosed-smiley:before {
   content: "\f02d";
 }
 
-.foundicon-search:before {
+.foundicon-enclosed-search:before {
   content: "\f02e";
 }

--- a/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons_ie7.css
+++ b/foundation_icons_general_enclosed/stylesheets/general_enclosed_foundicons_ie7.css
@@ -1,194 +1,194 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="foundicon-enclosed-"] {
   font-family: "GeneralEnclosedFoundicons";
   font-weight: normal;
   font-style: normal;
 }
 
-.foundicon-settings {
+.foundicon-enclosed-settings {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf000;");
 }
 
-.foundicon-heart {
+.foundicon-enclosed-heart {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf001;");
 }
 
-.foundicon-star {
+.foundicon-enclosed-star {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf002;");
 }
 
-.foundicon-plus {
+.foundicon-enclosed-plus {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf003;");
 }
 
-.foundicon-minus {
+.foundicon-enclosed-minus {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf004;");
 }
 
-.foundicon-checkmark {
+.foundicon-enclosed-checkmark {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf005;");
 }
 
-.foundicon-remove {
+.foundicon-enclosed-remove {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf006;");
 }
 
-.foundicon-mail {
+.foundicon-enclosed-mail {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf007;");
 }
 
-.foundicon-calendar {
+.foundicon-enclosed-calendar {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf008;");
 }
 
-.foundicon-page {
+.foundicon-enclosed-page {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf009;");
 }
 
-.foundicon-tools {
+.foundicon-enclosed-tools {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00a;");
 }
 
-.foundicon-globe {
+.foundicon-enclosed-globe {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00b;");
 }
 
-.foundicon-home {
+.foundicon-enclosed-home {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00c;");
 }
 
-.foundicon-quote {
+.foundicon-enclosed-quote {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00d;");
 }
 
-.foundicon-people {
+.foundicon-enclosed-people {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00e;");
 }
 
-.foundicon-monitor {
+.foundicon-enclosed-monitor {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00f;");
 }
 
-.foundicon-laptop {
+.foundicon-enclosed-laptop {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf010;");
 }
 
-.foundicon-phone {
+.foundicon-enclosed-phone {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf011;");
 }
 
-.foundicon-cloud {
+.foundicon-enclosed-cloud {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf012;");
 }
 
-.foundicon-error {
+.foundicon-enclosed-error {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf013;");
 }
 
-.foundicon-right-arrow {
+.foundicon-enclosed-right-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf014;");
 }
 
-.foundicon-left-arrow {
+.foundicon-enclosed-left-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf015;");
 }
 
-.foundicon-up-arrow {
+.foundicon-enclosed-up-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf016;");
 }
 
-.foundicon-down-arrow {
+.foundicon-enclosed-down-arrow {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf017;");
 }
 
-.foundicon-trash {
+.foundicon-enclosed-trash {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf018;");
 }
 
-.foundicon-add-doc {
+.foundicon-enclosed-add-doc {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf019;");
 }
 
-.foundicon-edit {
+.foundicon-enclosed-edit {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01a;");
 }
 
-.foundicon-lock {
+.foundicon-enclosed-lock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01b;");
 }
 
-.foundicon-unlock {
+.foundicon-enclosed-unlock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01c;");
 }
 
-.foundicon-refresh {
+.foundicon-enclosed-refresh {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01d;");
 }
 
-.foundicon-paper-clip {
+.foundicon-enclosed-paper-clip {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01e;");
 }
 
-.foundicon-video {
+.foundicon-enclosed-video {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01f;");
 }
 
-.foundicon-photo {
+.foundicon-enclosed-photo {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf020;");
 }
 
-.foundicon-graph {
+.foundicon-enclosed-graph {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf021;");
 }
 
-.foundicon-idea {
+.foundicon-enclosed-idea {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf022;");
 }
 
-.foundicon-mic {
+.foundicon-enclosed-mic {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf023;");
 }
 
-.foundicon-cart {
+.foundicon-enclosed-cart {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf024;");
 }
 
-.foundicon-address-book {
+.foundicon-enclosed-address-book {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf025;");
 }
 
-.foundicon-compass {
+.foundicon-enclosed-compass {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf026;");
 }
 
-.foundicon-flag {
+.foundicon-enclosed-flag {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf027;");
 }
 
-.foundicon-location {
+.foundicon-enclosed-location {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf028;");
 }
 
-.foundicon-clock {
+.foundicon-enclosed-clock {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf029;");
 }
 
-.foundicon-folder {
+.foundicon-enclosed-folder {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02a;");
 }
 
-.foundicon-inbox {
+.foundicon-enclosed-inbox {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02b;");
 }
 
-.foundicon-website {
+.foundicon-enclosed-website {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02c;");
 }
 
-.foundicon-smiley {
+.foundicon-enclosed-smiley {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02d;");
 }
 
-.foundicon-search {
+.foundicon-enclosed-search {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf02e;");
 }

--- a/foundation_icons_social/demo.html
+++ b/foundation_icons_social/demo.html
@@ -32,38 +32,38 @@
     .class { color: #4DB9EE; }
     em { color: #aaa; }
 
-    [class*="foundicon-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
+    [class*="foundicon-social-"]:after { position: relative; top: -8px; left: 10px; color: #888; font-size: 60%; font-style: normal; }
 
-    .foundicon-thumb-up:after         { content: "thumb-up";}
-    .foundicon-thumb-down:after       { content: "thumb-down";}
-    .foundicon-rss:after              { content: "rss";}
-    .foundicon-facebook:after         { content: "facebook";}
-    .foundicon-twitter:after          { content: "twitter";}
-    .foundicon-pinterest:after        { content: "pinterest";}
-    .foundicon-github:after           { content: "github";}
-    .foundicon-path:after             { content: "path";}
-    .foundicon-linkedin:after         { content: "linkedin";}
-    .foundicon-dribbble:after         { content: "dribbble";}
-    .foundicon-stumble-upon:after     { content: "stumble-upon";}
-    .foundicon-behance:after          { content: "behance";}
-    .foundicon-reddit:after           { content: "reddit";}
-    .foundicon-google-plus:after      { content: "google-plus";}
-    .foundicon-youtube:after          { content: "youtube";}
-    .foundicon-vimeo:after            { content: "vimeo";}
-    .foundicon-flickr:after           { content: "flickr";}
-    .foundicon-slideshare:after       { content: "slideshare";}
-    .foundicon-picassa:after          { content: "picassa";}
-    .foundicon-skype:after            { content: "skype";}
-    .foundicon-steam:after            { content: "steam";}
-    .foundicon-instagram:after        { content: "instagram";}
-    .foundicon-foursquare:after       { content: "foursquare";}
-    .foundicon-delicious:after        { content: "delicious";}
-    .foundicon-chat:after             { content: "chat";}
-    .foundicon-torso:after            { content: "torso";}
-    .foundicon-tumblr:after           { content: "tumblr";}
-    .foundicon-video-chat:after       { content: "video-chat";}
-    .foundicon-digg:after             { content: "digg";}
-    .foundicon-wordpress:after        { content: "wordpress";}
+    .foundicon-social-thumb-up:after         { content: "thumb-up";}
+    .foundicon-social-thumb-down:after       { content: "thumb-down";}
+    .foundicon-social-rss:after              { content: "rss";}
+    .foundicon-social-facebook:after         { content: "facebook";}
+    .foundicon-social-twitter:after          { content: "twitter";}
+    .foundicon-social-pinterest:after        { content: "pinterest";}
+    .foundicon-social-github:after           { content: "github";}
+    .foundicon-social-path:after             { content: "path";}
+    .foundicon-social-linkedin:after         { content: "linkedin";}
+    .foundicon-social-dribbble:after         { content: "dribbble";}
+    .foundicon-social-stumble-upon:after     { content: "stumble-upon";}
+    .foundicon-social-behance:after          { content: "behance";}
+    .foundicon-social-reddit:after           { content: "reddit";}
+    .foundicon-social-google-plus:after      { content: "google-plus";}
+    .foundicon-social-youtube:after          { content: "youtube";}
+    .foundicon-social-vimeo:after            { content: "vimeo";}
+    .foundicon-social-flickr:after           { content: "flickr";}
+    .foundicon-social-slideshare:after       { content: "slideshare";}
+    .foundicon-social-picassa:after          { content: "picassa";}
+    .foundicon-social-skype:after            { content: "skype";}
+    .foundicon-social-steam:after            { content: "steam";}
+    .foundicon-social-instagram:after        { content: "instagram";}
+    .foundicon-social-foursquare:after       { content: "foursquare";}
+    .foundicon-social-delicious:after        { content: "delicious";}
+    .foundicon-social-chat:after             { content: "chat";}
+    .foundicon-social-torso:after            { content: "torso";}
+    .foundicon-social-tumblr:after           { content: "tumblr";}
+    .foundicon-social-video-chat:after       { content: "video-chat";}
+    .foundicon-social-digg:after             { content: "digg";}
+    .foundicon-social-wordpress:after        { content: "wordpress";}
 
   </style>
 
@@ -87,41 +87,41 @@
     <div class="row">
 
       <ul class="four columns">
-        <li><i class="foundicon-thumb-up"></i></li>
-        <li><i class="foundicon-thumb-down"></i></li>
-        <li><i class="foundicon-rss"></i></li>
-        <li><i class="foundicon-facebook"></i></li>
-        <li><i class="foundicon-twitter"></i></li>
-        <li><i class="foundicon-pinterest"></i></li>
-        <li><i class="foundicon-github"></i></li>
-        <li><i class="foundicon-path"></i></li>
-        <li><i class="foundicon-linkedin"></i></li>
-        <li><i class="foundicon-dribbble"></i></li>
+        <li><i class="foundicon-social-thumb-up"></i></li>
+        <li><i class="foundicon-social-thumb-down"></i></li>
+        <li><i class="foundicon-social-rss"></i></li>
+        <li><i class="foundicon-social-facebook"></i></li>
+        <li><i class="foundicon-social-twitter"></i></li>
+        <li><i class="foundicon-social-pinterest"></i></li>
+        <li><i class="foundicon-social-github"></i></li>
+        <li><i class="foundicon-social-path"></i></li>
+        <li><i class="foundicon-social-linkedin"></i></li>
+        <li><i class="foundicon-social-dribbble"></i></li>
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-stumble-upon"></i></li>
-        <li><i class="foundicon-behance"></i></li>
-        <li><i class="foundicon-reddit"></i></li>
-        <li><i class="foundicon-google-plus"></i></li>
-        <li><i class="foundicon-youtube"></i></li>
-        <li><i class="foundicon-vimeo"></i></li>
-        <li><i class="foundicon-flickr"></i></li>
-        <li><i class="foundicon-slideshare"></i></li>
-        <li><i class="foundicon-picassa"></i></li>
-        <li><i class="foundicon-skype"></i></li>
+        <li><i class="foundicon-social-stumble-upon"></i></li>
+        <li><i class="foundicon-social-behance"></i></li>
+        <li><i class="foundicon-social-reddit"></i></li>
+        <li><i class="foundicon-social-google-plus"></i></li>
+        <li><i class="foundicon-social-youtube"></i></li>
+        <li><i class="foundicon-social-vimeo"></i></li>
+        <li><i class="foundicon-social-flickr"></i></li>
+        <li><i class="foundicon-social-slideshare"></i></li>
+        <li><i class="foundicon-social-picassa"></i></li>
+        <li><i class="foundicon-social-skype"></i></li>
       </ul>
 
       <ul class="four columns">
-        <li><i class="foundicon-instagram"></i></li>
-        <li><i class="foundicon-foursquare"></i></li>
-        <li><i class="foundicon-delicious"></i></li>
-        <li><i class="foundicon-chat"></i></li>
-        <li><i class="foundicon-torso"></i></li>
-        <li><i class="foundicon-tumblr"></i></li>
-        <li><i class="foundicon-video-chat"></i></li>
-        <li><i class="foundicon-digg"></i></li>
-        <li><i class="foundicon-wordpress"></i></li>
+        <li><i class="foundicon-social-instagram"></i></li>
+        <li><i class="foundicon-social-foursquare"></i></li>
+        <li><i class="foundicon-social-delicious"></i></li>
+        <li><i class="foundicon-social-chat"></i></li>
+        <li><i class="foundicon-social-torso"></i></li>
+        <li><i class="foundicon-social-tumblr"></i></li>
+        <li><i class="foundicon-social-video-chat"></i></li>
+        <li><i class="foundicon-social-digg"></i></li>
+        <li><i class="foundicon-social-wordpress"></i></li>
       </ul>
 
     </div>
@@ -131,7 +131,7 @@
         <h4>Here's the code:</h4>
         <div class="code">
 <pre>
-&lt;i class="<span class="class">foundicon-[icon]</span>"&gt;&lt;/i&gt;
+&lt;i class="<span class="class">foundicon-social-[icon]</span>"&gt;&lt;/i&gt;
 </pre>
         </div>
       </div>

--- a/foundation_icons_social/sass/_settings.scss
+++ b/foundation_icons_social/sass/_settings.scss
@@ -1,6 +1,6 @@
 $fontFileName: "../fonts/social_foundicons";
 $fontName: "SocialFoundicons";
-$classPrefix: "foundicon-";
+$classPrefix: "foundicon-social-";
 
 @mixin i-class($name,$pua) {
   .#{$classPrefix}#{$name}:before { 

--- a/foundation_icons_social/stylesheets/social_foundicons.css
+++ b/foundation_icons_social/stylesheets/social_foundicons.css
@@ -8,7 +8,7 @@
 }
 
 /* global foundicon styles */
-[class*="foundicon-"] {
+[class*="foundicon-social-"] {
   display: inline;
   width: auto;
   height: auto;
@@ -19,7 +19,7 @@
   background-repeat: repeat;
 }
 
-[class*="foundicon-"]:before {
+[class*="foundicon-social-"]:before {
   font-family: "SocialFoundicons";
   font-weight: normal;
   font-style: normal;
@@ -27,122 +27,122 @@
 }
 
 /* icons */
-.foundicon-thumb-up:before {
+.foundicon-social-thumb-up:before {
   content: "\f000";
 }
 
-.foundicon-thumb-down:before {
+.foundicon-social-thumb-down:before {
   content: "\f001";
 }
 
-.foundicon-rss:before {
+.foundicon-social-rss:before {
   content: "\f002";
 }
 
-.foundicon-facebook:before {
+.foundicon-social-facebook:before {
   content: "\f003";
 }
 
-.foundicon-twitter:before {
+.foundicon-social-twitter:before {
   content: "\f004";
 }
 
-.foundicon-pinterest:before {
+.foundicon-social-pinterest:before {
   content: "\f005";
 }
 
-.foundicon-github:before {
+.foundicon-social-github:before {
   content: "\f006";
 }
 
-.foundicon-path:before {
+.foundicon-social-path:before {
   content: "\f007";
 }
 
-.foundicon-linkedin:before {
+.foundicon-social-linkedin:before {
   content: "\f008";
 }
 
-.foundicon-dribbble:before {
+.foundicon-social-dribbble:before {
   content: "\f009";
 }
 
-.foundicon-stumble-upon:before {
+.foundicon-social-stumble-upon:before {
   content: "\f00a";
 }
 
-.foundicon-behance:before {
+.foundicon-social-behance:before {
   content: "\f00b";
 }
 
-.foundicon-reddit:before {
+.foundicon-social-reddit:before {
   content: "\f00c";
 }
 
-.foundicon-google-plus:before {
+.foundicon-social-google-plus:before {
   content: "\f00d";
 }
 
-.foundicon-youtube:before {
+.foundicon-social-youtube:before {
   content: "\f00e";
 }
 
-.foundicon-vimeo:before {
+.foundicon-social-vimeo:before {
   content: "\f00f";
 }
 
-.foundicon-flickr:before {
+.foundicon-social-flickr:before {
   content: "\f010";
 }
 
-.foundicon-slideshare:before {
+.foundicon-social-slideshare:before {
   content: "\f011";
 }
 
-.foundicon-picassa:before {
+.foundicon-social-picassa:before {
   content: "\f012";
 }
 
-.foundicon-skype:before {
+.foundicon-social-skype:before {
   content: "\f013";
 }
 
-.foundicon-steam:before {
+.foundicon-social-steam:before {
   content: "\f014";
 }
 
-.foundicon-instagram:before {
+.foundicon-social-instagram:before {
   content: "\f015";
 }
 
-.foundicon-foursquare:before {
+.foundicon-social-foursquare:before {
   content: "\f016";
 }
 
-.foundicon-delicious:before {
+.foundicon-social-delicious:before {
   content: "\f017";
 }
 
-.foundicon-chat:before {
+.foundicon-social-chat:before {
   content: "\f018";
 }
 
-.foundicon-torso:before {
+.foundicon-social-torso:before {
   content: "\f019";
 }
 
-.foundicon-tumblr:before {
+.foundicon-social-tumblr:before {
   content: "\f01a";
 }
 
-.foundicon-video-chat:before {
+.foundicon-social-video-chat:before {
   content: "\f01b";
 }
 
-.foundicon-digg:before {
+.foundicon-social-digg:before {
   content: "\f01c";
 }
 
-.foundicon-wordpress:before {
+.foundicon-social-wordpress:before {
   content: "\f01d";
 }

--- a/foundation_icons_social/stylesheets/social_foundicons_ie7.css
+++ b/foundation_icons_social/stylesheets/social_foundicons_ie7.css
@@ -1,126 +1,126 @@
 /* general icons for IE7 */
-[class*="foundicon-"] {
+[class*="foundicon-social-"] {
   font-family: "SocialFoundicons";
   font-weight: normal;
   font-style: normal;
 }
 
-.foundicon-thumb-up {
+.foundicon-social-thumb-up {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf000;");
 }
 
-.foundicon-thumb-down {
+.foundicon-social-thumb-down {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf001;");
 }
 
-.foundicon-rss {
+.foundicon-social-rss {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf002;");
 }
 
-.foundicon-facebook {
+.foundicon-social-facebook {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf003;");
 }
 
-.foundicon-twitter {
+.foundicon-social-twitter {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf004;");
 }
 
-.foundicon-pinterest {
+.foundicon-social-pinterest {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf005;");
 }
 
-.foundicon-github {
+.foundicon-social-github {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf006;");
 }
 
-.foundicon-path {
+.foundicon-social-path {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf007;");
 }
 
-.foundicon-linkedin {
+.foundicon-social-linkedin {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf008;");
 }
 
-.foundicon-dribbble {
+.foundicon-social-dribbble {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf009;");
 }
 
-.foundicon-stumble-upon {
+.foundicon-social-stumble-upon {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00a;");
 }
 
-.foundicon-behance {
+.foundicon-social-behance {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00b;");
 }
 
-.foundicon-reddit {
+.foundicon-social-reddit {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00c;");
 }
 
-.foundicon-google-plus {
+.foundicon-social-google-plus {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00d;");
 }
 
-.foundicon-youtube {
+.foundicon-social-youtube {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00e;");
 }
 
-.foundicon-vimeo {
+.foundicon-social-vimeo {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf00f;");
 }
 
-.foundicon-flickr {
+.foundicon-social-flickr {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf010;");
 }
 
-.foundicon-slideshare {
+.foundicon-social-slideshare {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf011;");
 }
 
-.foundicon-picassa {
+.foundicon-social-picassa {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf012;");
 }
 
-.foundicon-skype {
+.foundicon-social-skype {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf013;");
 }
 
-.foundicon-steam {
+.foundicon-social-steam {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf014;");
 }
 
-.foundicon-instagram {
+.foundicon-social-instagram {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf015;");
 }
 
-.foundicon-foursquare {
+.foundicon-social-foursquare {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf016;");
 }
 
-.foundicon-delicious {
+.foundicon-social-delicious {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf017;");
 }
 
-.foundicon-chat {
+.foundicon-social-chat {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf018;");
 }
 
-.foundicon-torso {
+.foundicon-social-torso {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf019;");
 }
 
-.foundicon-tumblr {
+.foundicon-social-tumblr {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01a;");
 }
 
-.foundicon-video-chat {
+.foundicon-social-video-chat {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01b;");
 }
 
-.foundicon-digg {
+.foundicon-social-digg {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01c;");
 }
 
-.foundicon-wordpress {
+.foundicon-social-wordpress {
   *zoom: expression(this.runtimeStyle['zoom'] = "1", this.innerHTML = "&#xf01d;");
 }


### PR DESCRIPTION
Hi,
I had a problem : using bower, I installed foundation-icons and had to use 2 different sets on my project.
The problem was that general set and social set were conflicting using sass files:
The font family for my general icons were overwritten by social icons font.

So, I propose to add the set to change the default code to use icons from : `<i class="foundicon-[icon]"></i>` to `<i class="foundicon-[set]-[icon]"></i>`.

I used :  
- `general` for the general set
- `accessibility` for the accessibility set
- `enclosed` for the general enclosed set
- `social` for the social set.

I think it easily solve the problem for people using your fantastic tool.

Thanks for your interest,
Julien