### PR TITLE
Usage instructions update

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Usage
 =====
 * Download the icon font that you're interested in.
 * Merge the `fonts` and `stylesheets`, or `sass` if you are using it, folders into your Foundation project.
-* The default code is `<i class="foundicon-[icon]"></i>`, feel free to customize that to your needs.
+* The default code is `<i class="fi-[set]-[icon]"></i>`, feel free to customize that to your needs.
 * Style the icons using any CSS style that could apply to text!
 
 Repo Contents


### PR DESCRIPTION
'foundicons' is no longer used in the CSS. Also, added [set] because some of the icons, particularly the social ones, have relevant prefix
